### PR TITLE
Update multiple-arguments.rst

### DIFF
--- a/graphql/manual/queries/multiple-arguments.rst
+++ b/graphql/manual/queries/multiple-arguments.rst
@@ -1,6 +1,6 @@
 Using multiple arguments in a query
 ===================================
-Multiple arguments can be used together in the same query. For e.g. if you want to use the ``where`` argument to
+Multiple arguments can be used together in the same query. For example, if you want to use the ``where`` argument to
 filter the results and then use the ``order_by`` argument to sort them.
 
 For example, fetch a list of authors and only 2 of their published articles that are sorted by their date of publication:


### PR DESCRIPTION
e.g. itself means for example. So either only use `e.g.` or `for example`. The current sentence is read as `for for example`.